### PR TITLE
Geyser/Floodgate support; add knockbacksync.exempt permission

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
             <id>codemc-releases</id>
             <url>https://repo.codemc.io/repository/maven-releases/</url>
         </repository>
+        <repository>
+            <id>opencollab</id>
+            <url>https://repo.opencollab.dev/maven-snapshots/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -97,6 +101,12 @@
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
             <version>1.326</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geysermc.floodgate</groupId>
+            <artifactId>api</artifactId>
+            <version>2.0-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/me/caseload/knockbacksync/manager/PlayerDataManager.java
+++ b/src/main/java/me/caseload/knockbacksync/manager/PlayerDataManager.java
@@ -1,19 +1,52 @@
 package me.caseload.knockbacksync.manager;
 
+import io.github.retrooper.packetevents.util.GeyserUtil;
+import me.caseload.knockbacksync.util.FloodgateUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class PlayerDataManager {
 
-    private static final Map<UUID, PlayerData> playerDataMap = new HashMap<>();
+    private static final Map<UUID, PlayerData> playerDataMap = new ConcurrentHashMap<>();
+    public static final Collection<UUID> exemptPlayers = Collections.synchronizedCollection(new HashSet<>());
 
     public static @NotNull PlayerData getPlayerData(UUID uuid) {
         return playerDataMap.get(uuid);
     }
 
     public static void addPlayerData(UUID uuid, PlayerData playerData) {
-        playerDataMap.put(uuid, playerData);
+        if (shouldCheck(uuid)) {
+            playerDataMap.put(uuid, playerData);
+        }
+    }
+
+    public static boolean shouldCheck(UUID uuid) {
+        if (exemptPlayers.contains(uuid)) return false;
+
+        if (uuid != null) {
+            // Geyser players don't have Java movement
+            if (GeyserUtil.isGeyserPlayer(uuid)
+                // Floodgate is the authentication system for Geyser on servers that use Geyser as a proxy instead of installing it as a plugin directly on the server
+                || FloodgateUtil.isFloodgatePlayer(uuid)
+                // Geyser formatted player string
+                // This will never happen for Java players, as the first character in the 3rd group is always 4 (xxxxxxxx-xxxx-4xxx-xxxx-xxxxxxxxxxxx)
+                || uuid.toString().startsWith("00000000-0000-0000-0009")) {
+                exemptPlayers.add(uuid);
+                return false;
+            }
+
+            // Has exempt permission
+            Player player = Bukkit.getPlayer(uuid);
+            if (player != null && player.hasPermission("knockbacksync.exempt")) {
+                exemptPlayers.add(uuid);
+                return false;
+            }
+        }
+        return true;
     }
 
     public static void removePlayerData(UUID uuid) {

--- a/src/main/java/me/caseload/knockbacksync/util/FloodgateUtil.java
+++ b/src/main/java/me/caseload/knockbacksync/util/FloodgateUtil.java
@@ -1,0 +1,31 @@
+package me.caseload.knockbacksync.util;
+
+import org.geysermc.floodgate.api.FloodgateApi;
+
+import java.util.UUID;
+
+public class FloodgateUtil {
+
+    private static boolean CHECKED_FOR_FLOODGATE;
+    private static boolean FLOODGATE_PRESENT;
+
+    public static boolean isFloodgatePlayer(UUID uuid) {
+        if (!CHECKED_FOR_FLOODGATE) {
+            try {
+                Class.forName("org.geysermc.floodgate.api.FloodgateApi");
+                FLOODGATE_PRESENT = true;
+            } catch (ClassNotFoundException e) {
+                FLOODGATE_PRESENT = false;
+            }
+            CHECKED_FOR_FLOODGATE = true;
+        }
+
+        if (FLOODGATE_PRESENT) {
+            return FloodgateApi.getInstance().isFloodgatePlayer(uuid);
+        } else {
+            return false;
+        }
+    }
+
+}
+


### PR DESCRIPTION
Automatically exempts Geyser/Floodgate players.

Adds a new permission that can be set to exempt a player from undergoing to effects of knockbacksync. Requires relog.