### PR TITLE
Add new /kbsync status command

### DIFF
--- a/src/main/java/me/caseload/knockbacksync/command/MainCommand.java
+++ b/src/main/java/me/caseload/knockbacksync/command/MainCommand.java
@@ -3,6 +3,7 @@ package me.caseload.knockbacksync.command;
 import dev.jorel.commandapi.CommandAPICommand;
 import me.caseload.knockbacksync.command.subcommand.PingSubcommand;
 import me.caseload.knockbacksync.command.subcommand.ReloadSubcommand;
+import me.caseload.knockbacksync.command.subcommand.StatusSubcommand;
 import me.caseload.knockbacksync.command.subcommand.ToggleSubcommand;
 import org.bukkit.ChatColor;
 
@@ -14,6 +15,7 @@ public class MainCommand {
                 .withSubcommand(new PingSubcommand().getCommand())
                 .withSubcommand(new ToggleSubcommand().getCommand())
                 .withSubcommand(new ReloadSubcommand().getCommand())
+                .withSubcommand(new StatusSubcommand().getCommand())
                 .executes((sender, args) -> {
                     sender.sendMessage(ChatColor.translateAlternateColorCodes(
                             '&',

--- a/src/main/java/me/caseload/knockbacksync/command/subcommand/StatusSubcommand.java
+++ b/src/main/java/me/caseload/knockbacksync/command/subcommand/StatusSubcommand.java
@@ -1,0 +1,52 @@
+package me.caseload.knockbacksync.command.subcommand;
+
+import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.CommandPermission;
+import dev.jorel.commandapi.arguments.PlayerArgument;
+import me.caseload.knockbacksync.KnockbackSync;
+import me.caseload.knockbacksync.manager.ConfigManager;
+import me.caseload.knockbacksync.manager.PlayerDataManager;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.Listener;
+
+import java.util.UUID;
+
+public class StatusSubcommand implements Listener {
+
+    public CommandAPICommand getCommand() {
+        return new CommandAPICommand("status")
+                .withPermission(CommandPermission.NONE)
+                .withOptionalArguments(new PlayerArgument("target"))
+                .executes((sender, args) -> {
+                    ConfigManager configManager = KnockbackSync.getInstance().getConfigManager();
+                    Player target = (Player) args.get("target");
+
+                    // Show global status
+                    boolean globalStatus = configManager.isToggled();
+                    sender.sendMessage(ChatColor.YELLOW + "Global KnockbackSync status: " +
+                            (globalStatus ? ChatColor.GREEN + "Enabled" : ChatColor.RED + "Disabled"));
+
+                    // Show player status
+                    if (target == null && sender instanceof Player) {
+                        target = (Player) sender;
+                    }
+
+                    if (target != null) {
+                        if (sender.hasPermission("knockbacksync.status.self") ||
+                                (sender.hasPermission("knockbacksync.status.other") && !sender.equals(target))) {
+
+                            UUID uuid = target.getUniqueId();
+                            boolean playerStatus = !PlayerDataManager.containsPlayerData(uuid);
+
+                            sender.sendMessage(ChatColor.YELLOW + target.getName() + "'s KnockbackSync status: " +
+                                    (playerStatus ? ChatColor.GREEN + "Enabled" : ChatColor.RED + "Disabled"));
+                        } else {
+                            sender.sendMessage(ChatColor.RED + "You don't have permission to check the status for " +
+                                    (sender.equals(target) ? "yourself" : "other players") + ".");
+                        }
+                    }
+                });
+    }
+}

--- a/src/main/java/me/caseload/knockbacksync/command/subcommand/StatusSubcommand.java
+++ b/src/main/java/me/caseload/knockbacksync/command/subcommand/StatusSubcommand.java
@@ -8,7 +8,6 @@ import me.caseload.knockbacksync.manager.ConfigManager;
 import me.caseload.knockbacksync.manager.PlayerDataManager;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
-import org.bukkit.command.CommandSender;
 import org.bukkit.event.Listener;
 
 import java.util.UUID;
@@ -40,8 +39,13 @@ public class StatusSubcommand implements Listener {
                             UUID uuid = target.getUniqueId();
                             boolean playerStatus = !PlayerDataManager.containsPlayerData(uuid);
 
-                            sender.sendMessage(ChatColor.YELLOW + target.getName() + "'s KnockbackSync status: " +
-                                    (playerStatus ? ChatColor.GREEN + "Enabled" : ChatColor.RED + "Disabled"));
+                            if (!globalStatus) {
+                                sender.sendMessage(ChatColor.YELLOW + target.getName() + "'s KnockbackSync status: " +
+                                        ChatColor.RED + "Disabled (Global toggle is off)");
+                            } else {
+                                sender.sendMessage(ChatColor.YELLOW + target.getName() + "'s KnockbackSync status: " +
+                                        (playerStatus ? ChatColor.GREEN + "Enabled" : ChatColor.RED + "Disabled"));
+                            }
                         } else {
                             sender.sendMessage(ChatColor.RED + "You don't have permission to check the status for " +
                                     (sender.equals(target) ? "yourself" : "other players") + ".");

--- a/src/main/java/me/caseload/knockbacksync/command/subcommand/StatusSubcommand.java
+++ b/src/main/java/me/caseload/knockbacksync/command/subcommand/StatusSubcommand.java
@@ -47,7 +47,9 @@ public class StatusSubcommand implements Listener {
                                         (playerStatus ? ChatColor.GREEN + "Enabled" : ChatColor.RED + "Disabled"));
                             }
                         } else {
-                            sender.sendMessage(ChatColor.RED + "You don't have permission to check the status for " +
+                            sender.sendMessage(ChatColor.RED + "You don't have the "
+                                    + (sender.equals(target) ? "knockbacksync.status.self" : "knockbacksync.status.other") +
+                                    " permission needed to check status for " +
                                     (sender.equals(target) ? "yourself" : "other players") + ".");
                         }
                     }

--- a/src/main/java/me/caseload/knockbacksync/command/subcommand/ToggleSubcommand.java
+++ b/src/main/java/me/caseload/knockbacksync/command/subcommand/ToggleSubcommand.java
@@ -1,14 +1,16 @@
 package me.caseload.knockbacksync.command.subcommand;
 
 import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.CommandPermission;
 import dev.jorel.commandapi.arguments.PlayerArgument;
 import me.caseload.knockbacksync.KnockbackSync;
 import me.caseload.knockbacksync.manager.ConfigManager;
-import me.caseload.knockbacksync.manager.PlayerData;
 import me.caseload.knockbacksync.manager.PlayerDataManager;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
+import org.bukkit.command.CommandSender;
 import org.bukkit.event.Listener;
+import org.bukkit.util.permissions.CommandPermissions;
 
 import java.util.UUID;
 
@@ -16,7 +18,7 @@ public class ToggleSubcommand implements Listener {
 
     public CommandAPICommand getCommand() {
         return new CommandAPICommand("toggle")
-                .withPermission("knockbacksync.toggle")
+                .withPermission(CommandPermission.NONE)
                 .withOptionalArguments(new PlayerArgument("target"))
                 .executes((sender, args) -> {
                     ConfigManager configManager = KnockbackSync.getInstance().getConfigManager();
@@ -24,28 +26,48 @@ public class ToggleSubcommand implements Listener {
                     String message;
 
                     if (target == null) {
-                        boolean toggledState = !configManager.isToggled();
-                        configManager.setToggled(toggledState);
+                        // Global toggle
+                        if (sender.hasPermission("knockbacksync.toggle.global")) {
+                            boolean toggledState = !configManager.isToggled();
+                            configManager.setToggled(toggledState);
 
-                        KnockbackSync.getInstance().getConfig().set("enabled", toggledState);
-                        KnockbackSync.getInstance().saveConfig();
+                            KnockbackSync.getInstance().getConfig().set("enabled", toggledState);
+                            KnockbackSync.getInstance().saveConfig();
 
-                        message = ChatColor.translateAlternateColorCodes('&',
-                                toggledState ? configManager.getEnableMessage() : configManager.getDisableMessage()
-                        );
+                            message = ChatColor.translateAlternateColorCodes('&',
+                                    toggledState ? configManager.getEnableMessage() : configManager.getDisableMessage()
+                            );
+                        } else {
+                            message = ChatColor.RED + "You don't have permission to toggle the global setting.";
+                        }
+                        sender.sendMessage(message);
+                    } else {
+                        // Player-specific toggle
+                        if (!configManager.isToggled()) {
+                            message = ChatColor.RED + "Knockbacksync is currently disabled on this server. Contact your server administrator for more information.";
+                            sender.sendMessage(message);
+                        } else if (sender instanceof Player && sender.equals(target) && sender.hasPermission("knockbacksync.toggle.self")) {
+                            togglePlayerKnockback(target, configManager, sender);
+                        } else if (sender.hasPermission("knockbacksync.toggle.other")) {
+                            togglePlayerKnockback(target, configManager, sender);
+                        } else {
+                            message = ChatColor.RED + "You don't have permission to toggle knockback for " +
+                                    (sender.equals(target) ? "yourself" : "other players") + ".";
+                            sender.sendMessage(message);
+                        }
                     }
-                    else {
-                        UUID uuid = target.getUniqueId();
-
-                        boolean isExempt = PlayerDataManager.isExempt(uuid);
-                        PlayerDataManager.setExempt(uuid, !isExempt);
-
-                        message = ChatColor.translateAlternateColorCodes('&',
-                                isExempt ? configManager.getPlayerEnableMessage() : configManager.getPlayerDisableMessage()
-                        ).replace("%player%", target.getName());
-                    }
-
-                    sender.sendMessage(message);
                 });
+    }
+
+    private void togglePlayerKnockback(Player target, ConfigManager configManager, CommandSender sender) {
+        UUID uuid = target.getUniqueId();
+        boolean isExempt = PlayerDataManager.isExempt(uuid);
+        PlayerDataManager.setExempt(uuid, !isExempt);
+
+        String message = ChatColor.translateAlternateColorCodes('&',
+                isExempt ? configManager.getPlayerEnableMessage() : configManager.getPlayerDisableMessage()
+        ).replace("%player%", target.getName());
+
+        sender.sendMessage(message);
     }
 }

--- a/src/main/java/me/caseload/knockbacksync/command/subcommand/ToggleSubcommand.java
+++ b/src/main/java/me/caseload/knockbacksync/command/subcommand/ToggleSubcommand.java
@@ -1,6 +1,7 @@
 package me.caseload.knockbacksync.command.subcommand;
 
 import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.CommandPermission;
 import dev.jorel.commandapi.arguments.PlayerArgument;
 import me.caseload.knockbacksync.KnockbackSync;
 import me.caseload.knockbacksync.manager.ConfigManager;
@@ -8,6 +9,7 @@ import me.caseload.knockbacksync.manager.PlayerData;
 import me.caseload.knockbacksync.manager.PlayerDataManager;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
+import org.bukkit.command.CommandSender;
 import org.bukkit.event.Listener;
 
 import java.util.UUID;
@@ -16,7 +18,7 @@ public class ToggleSubcommand implements Listener {
 
     public CommandAPICommand getCommand() {
         return new CommandAPICommand("toggle")
-                .withPermission("knockbacksync.toggle")
+                .withPermission(CommandPermission.NONE)
                 .withOptionalArguments(new PlayerArgument("target"))
                 .executes((sender, args) -> {
                     ConfigManager configManager = KnockbackSync.getInstance().getConfigManager();
@@ -24,40 +26,61 @@ public class ToggleSubcommand implements Listener {
                     String message;
 
                     if (target == null) {
-                        boolean toggledState = !configManager.isToggled();
-                        configManager.setToggled(toggledState);
+                        // Global toggle
+                        if (sender.hasPermission("knockbacksync.toggle.global")) {
+                            boolean toggledState = !configManager.isToggled();
+                            configManager.setToggled(toggledState);
 
-                        KnockbackSync.getInstance().getConfig().set("enabled", toggledState);
-                        KnockbackSync.getInstance().saveConfig();
+                            KnockbackSync.getInstance().getConfig().set("enabled", toggledState);
+                            KnockbackSync.getInstance().saveConfig();
 
-                        message = ChatColor.translateAlternateColorCodes('&',
-                                toggledState ? configManager.getEnableMessage() : configManager.getDisableMessage()
-                        );
-                    }
-                    else {
-                        UUID uuid = target.getUniqueId();
-
-                        if (PlayerDataManager.shouldExempt(uuid)) {
                             message = ChatColor.translateAlternateColorCodes('&',
-                                    configManager.getPlayerIneligibleMessage()
-                            ).replace("%player%", target.getName());
-
-                            sender.sendMessage(message);
-                            return;
+                                    toggledState ? configManager.getEnableMessage() : configManager.getDisableMessage()
+                            );
+                        } else {
+                            message = ChatColor.RED + "You don't have permission to toggle the global setting.";
                         }
-
-                        boolean hasPlayerData = PlayerDataManager.containsPlayerData(uuid);
-                        if (hasPlayerData)
-                            PlayerDataManager.removePlayerData(uuid);
-                        else
-                            PlayerDataManager.addPlayerData(uuid, new PlayerData(target));
-
-                        message = ChatColor.translateAlternateColorCodes('&',
-                                hasPlayerData ? configManager.getPlayerDisableMessage() : configManager.getPlayerEnableMessage()
-                        ).replace("%player%", target.getName());
+                        sender.sendMessage(message);
+                    } else {
+                        // Player-specific toggle
+                        if (!configManager.isToggled()) {
+                            message = ChatColor.RED + "Knockbacksync is currently disabled on this server. Contact your server administrator for more information.";
+                            sender.sendMessage(message);
+                        } else if (sender instanceof Player && sender.equals(target) && sender.hasPermission("knockbacksync.toggle.self")) {
+                            togglePlayerKnockback(target, configManager, sender);
+                        } else if (sender.hasPermission("knockbacksync.toggle.other")) {
+                            togglePlayerKnockback(target, configManager, sender);
+                        } else {
+                            message = ChatColor.RED + "You don't have permission to toggle knockback for " +
+                                    (sender.equals(target) ? "yourself" : "other players") + ".";
+                            sender.sendMessage(message);
+                        }
                     }
-
-                    sender.sendMessage(message);
                 });
+    }
+
+    private void togglePlayerKnockback(Player target, ConfigManager configManager, CommandSender sender) {
+        UUID uuid = target.getUniqueId();
+
+        if (PlayerDataManager.shouldExempt(uuid)) {
+            String message = ChatColor.translateAlternateColorCodes('&',
+                    configManager.getPlayerIneligibleMessage()
+            ).replace("%player%", target.getName());
+
+            sender.sendMessage(message);
+            return;
+        }
+
+        boolean hasPlayerData = PlayerDataManager.containsPlayerData(uuid);
+        if (hasPlayerData)
+            PlayerDataManager.removePlayerData(uuid);
+        else
+            PlayerDataManager.addPlayerData(uuid, new PlayerData(target));
+
+        String message = ChatColor.translateAlternateColorCodes('&',
+                hasPlayerData ? configManager.getPlayerDisableMessage() : configManager.getPlayerEnableMessage()
+        ).replace("%player%", target.getName());
+
+        sender.sendMessage(message);
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,7 +7,11 @@ description: Synchronizes player knockback for smoother gameplay.
 permissions:
   knockbacksync.update:
     default: op
-  knockbacksync.toggle:
+  knockbacksync.toggle.global:
+    default: op
+  knockbacksync.toggle.other:
+    default: op
+  knockbacksync.toggle.self:
     default: op
   knockbacksync.ping:
     default: op


### PR DESCRIPTION
When the global toggle is off, the player status message now explicitly states that the plugin is disabled for the player, regardless of their individual setting.