### PR TITLE
Support 26.2mc, update incendo:cloud-paper, and packetevents shade(s)

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -40,11 +40,11 @@ dependencies {
 
     shadeThisThing(implementation("org.kohsuke:github-api:1.326")!!)
     if (shadePE) {
-        shadeThisThing(implementation("com.github.retrooper:packetevents-spigot:2.11.2")!!)
+        shadeThisThing(implementation("com.github.retrooper:packetevents-spigot:2.13.0")!!)
     } else {
-        compileOnly("com.github.retrooper:packetevents-spigot:2.11.2")
+        compileOnly("com.github.retrooper:packetevents-spigot:2.13.0")
     }
-    shadeThisThing(implementation("org.incendo:cloud-paper:2.0.0-beta.14")!!)
+    shadeThisThing(implementation("org.incendo:cloud-paper:2.0.0-beta.17")!!)
     shadeThisThing(implementation("org.incendo:cloud-core:2.0.0")!!)
 
     // Required for 1.14.4 support because gson is too old to have JosnParser.parseString()


### PR DESCRIPTION
Updates the dependencies 